### PR TITLE
Add permissions for camera, audio, and storage access in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,6 +18,13 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
+            "permissions": [
+              "android.permission.CAMERA",
+              "android.permission.RECORD_AUDIO",
+              "android.permission.READ_EXTERNAL_STORAGE",
+              "android.permission.WRITE_EXTERNAL_STORAGE",
+              "android.permission.ACCESS_MEDIA_LOCATION"
+      ],
       "package": "com.morepriyam.pulse"
     },
     "web": {
@@ -34,6 +41,22 @@
           "imageWidth": 200,
           "resizeMode": "contain",
           "backgroundColor": "#ffffff"
+        }
+      ],
+      [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos.",
+          "isAccessMediaLocationEnabled": true
+        }
+      ],
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
+          "recordAudioAndroid": true
         }
       ],
       "expo-video",


### PR DESCRIPTION
This pull request updates the `app.json` configuration file to enhance permissions and integrate new Expo modules for media and camera functionalities. The changes focus on enabling specific permissions and configuring module settings for improved app capabilities.

### Permissions updates:

* Added Android permissions for camera access, audio recording, external storage read/write, and media location access in the `permissions` section.

### Expo module integrations:

* Configured `expo-media-library` with permissions for accessing and saving photos, along with enabling media location access.
* Configured `expo-camera` with permissions for camera and microphone access, and enabled audio recording on Android.