### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to TestFlight
+permissions:
+  contents: read
 
 "on":
   # Manual workflow dispatch - can be triggered from GitHub Actions UI


### PR DESCRIPTION
Potential fix for [https://github.com/mieweb/pulse/security/code-scanning/1](https://github.com/mieweb/pulse/security/code-scanning/1)

The best way to address this problem is to explicitly add a `permissions` block at the top-level of the workflow YAML file (.github/workflows/testflight-deploy.yml), or within the `deploy-ios` job. The minimal safe setting is `permissions: { contents: read }`, which grants read-only access to repository contents. This permission is sufficient for checking out code or reading other resources, but not for making modifications, creating releases, or interacting with issues or pull requests. If the workflow does not require more permissions, this is the safest and recommended default.

Insert the following at the top level—ideally immediately after the `name:` and before `on:`—to apply to the whole workflow. If more granular or job-specific permissions are needed in the future, those can be set at the job level.

**Steps:**  
- In `.github/workflows/testflight-deploy.yml`, add the following after the name (line 1) and before the `on:` key (line 3):

```yaml
permissions:
  contents: read
```
This will ensure the workflow only has minimal required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
