### PR TITLE
fix: reset video player state to ensure correct playback visibility

### DIFF
--- a/app/preview.tsx
+++ b/app/preview.tsx
@@ -297,6 +297,9 @@ export default function PreviewScreen() {
 
       setConcatenatedVideoUri(outputUri);
 
+      // Reset useSecondPlayer to false so player1 (with concatenated video) is visible
+      setUseSecondPlayer(false);
+
       // Load concatenated video
       console.log("📺 Loading concatenated video into player...");
       setIsLoadingVideo(true);


### PR DESCRIPTION
- Added a line to reset the useSecondPlayer state to false, ensuring that the primary video player with the concatenated video is visible after loading. This change improves user experience by maintaining the expected video playback behavior.