### PR TITLE
fix: resolve code signing issues in GitHub Actions workflow

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -80,15 +80,21 @@ jobs:
       - name: Build iOS Archive
         if: ${{ !inputs.skip_build || inputs.skip_build == false }}
         run: |
+          # Create build directory
+          mkdir -p ./build
+          
+          # Build without code signing for CI (will be signed during export)
           xcodebuild archive \
             -workspace $IOS_WORKSPACE \
             -scheme $IOS_SCHEME \
             -configuration $IOS_CONFIGURATION \
             -destination $IOS_DESTINATION \
             -archivePath ./build/pulse.xcarchive \
-            -allowProvisioningUpdates \
-            CODE_SIGN_STYLE=Automatic \
-            DEVELOPMENT_TEAM=$APPLE_TEAM_ID
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="" \
+            PROVISIONING_PROFILE_SPECIFIER="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
 
       - name: Export IPA
         if: ${{ !inputs.skip_build || inputs.skip_build == false }}
@@ -108,6 +114,8 @@ jobs:
               <true/>
               <key>compileBitcode</key>
               <false/>
+              <key>signingStyle</key>
+              <string>automatic</string>
           </dict>
           </plist>
           EOF
@@ -115,7 +123,8 @@ jobs:
           xcodebuild -exportArchive \
             -archivePath ./build/pulse.xcarchive \
             -exportPath ./build \
-            -exportOptionsPlist exportOptions.plist
+            -exportOptionsPlist exportOptions.plist \
+            -allowProvisioningUpdates
 
       - name: Upload to TestFlight
         if: ${{ !inputs.skip_build || inputs.skip_build == false }}


### PR DESCRIPTION
- Disable code signing during build to avoid provisioning profile errors
- Handle code signing during export step with automatic signing
- Add proper build directory creation
- Update export options for automatic signing