### PR TITLE
fix: add Apple authentication before archive step

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -77,6 +77,14 @@ jobs:
           pod install --repo-update
           cd ..
 
+      - name: Authenticate with Apple
+        if: ${{ !inputs.skip_build || inputs.skip_build == false }}
+        run: |
+          # Authenticate with Apple using altool
+          xcrun altool --store-password-in-keychain-item "ALTOOL_AUTH" \
+            -u "${APPLE_ID}" \
+            -p "${APPLE_ID_PASSWORD}"
+
       - name: Build iOS Archive
         if: ${{ !inputs.skip_build || inputs.skip_build == false }}
         run: |


### PR DESCRIPTION
- Add xcrun altool authentication step before build
- Remove invalid Apple ID flags from xcodebuild archive
- Fix 'No Accounts' and 'No profiles' errors
- Ensure proper authentication flow for automatic signing