### PR TITLE
Add export compliance for encryption

### DIFF
--- a/ios/pulse/Info.plist
+++ b/ios/pulse/Info.plist
@@ -83,5 +83,7 @@
     <string>Automatic</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <false/>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
   </dict>
 </plist>


### PR DESCRIPTION
Set ITSAppUsesNonExemptEncryption to false to skip manual compliance step