### PR TITLE
Add export compliance to app.json for expo prebuild

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,10 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.mieweb.pulse"
+      "bundleIdentifier": "com.mieweb.pulse",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/ios/pulse/Info.plist
+++ b/ios/pulse/Info.plist
@@ -34,6 +34,8 @@
     </array>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>LSMinimumSystemVersion</key>
     <string>12.0</string>
     <key>LSRequiresIPhoneOS</key>
@@ -82,8 +84,6 @@
     <key>UIUserInterfaceStyle</key>
     <string>Automatic</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
-    <false/>
-    <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
   </dict>
 </plist>


### PR DESCRIPTION
Set ITSAppUsesNonExemptEncryption to false in app.json so it persists through expo prebuild