### PR TITLE
Deeplink duration + validation fixes (recording warning states, upload disable, trim-sync refresh)

### DIFF
--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -377,10 +377,11 @@ export default function ShortsScreen() {
         const draftToReload = draftId || currentDraftId;
         if (draftToReload) {
           try {
-            const draft = await DraftStorage.getDraftById(
-              draftToReload,
-              "camera"
-            );
+            const draft =
+              (await DraftStorage.getDraftById(draftToReload, draftMode)) ||
+              (draftMode === "upload"
+                ? await DraftStorage.getDraftById(draftToReload, "camera")
+                : await DraftStorage.getDraftById(draftToReload, "upload"));
             if (draft) {
               if (draft.segments) {
                 const segmentsWithAbsolutePaths =
@@ -398,7 +399,13 @@ export default function ShortsScreen() {
         }
       };
       reloadDraft();
-    }, [draftId, currentDraftId, setRecordingSegments, maxDurationLimitSeconds])
+    }, [
+      draftId,
+      currentDraftId,
+      setRecordingSegments,
+      maxDurationLimitSeconds,
+      draftMode,
+    ])
   );
 
   const handleTimeSelect = (newDurationLimitSeconds: number) => {

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -60,10 +60,26 @@ export default function ShortsScreen() {
     mode?: string;
     server?: string;
     token?: string;
+    duration?: string;
   }>();
+  const parseDurationParam = React.useCallback((value?: string) => {
+    if (!value) return undefined;
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+    return parsed;
+  }, []);
+  const deeplinkDurationSeconds = parseDurationParam(
+    useLocalSearchParams<{ duration?: string }>().duration
+  );
   const draftMode = (mode === "upload" ? "upload" : "camera") as
     | "camera"
     | "upload";
+  const [lockedDurationSeconds, setLockedDurationSeconds] =
+    React.useState<number | null>(deeplinkDurationSeconds ?? null);
+  const [lockedDurationBlinkVisible, setLockedDurationBlinkVisible] =
+    React.useState(true);
+  const [warningIconBlinkVisible, setWarningIconBlinkVisible] =
+    React.useState(true);
   
   // Store per-draft config only when QR includes draftId (required for upload)
   const serverNotSetupForUpload = useLocalSearchParams<{ serverNotSetupForUpload?: string }>().serverNotSetupForUpload === "true";
@@ -72,7 +88,12 @@ export default function ShortsScreen() {
       if (server && token && draftId) {
         try {
           const { storeUploadConfigForDraft } = await import("@/utils/uploadConfig");
-          await storeUploadConfigForDraft(draftId, server, token);
+          await storeUploadConfigForDraft(
+            draftId,
+            server,
+            token,
+            deeplinkDurationSeconds
+          );
           console.log("✅ Stored upload config for draft", draftId);
         } catch (error) {
           console.error("❌ Failed to store upload config:", error);
@@ -80,7 +101,29 @@ export default function ShortsScreen() {
       }
     };
     storeConfig();
-  }, [draftId, server, token]);
+  }, [draftId, server, token, deeplinkDurationSeconds]);
+
+  React.useEffect(() => {
+    const loadDurationFromConfig = async () => {
+      if (deeplinkDurationSeconds) {
+        setLockedDurationSeconds(deeplinkDurationSeconds);
+        return;
+      }
+      if (draftMode !== "upload" || !draftId) {
+        setLockedDurationSeconds(null);
+        return;
+      }
+      try {
+        const { getUploadConfigForDraft } = await import("@/utils/uploadConfig");
+        const config = await getUploadConfigForDraft(draftId);
+        setLockedDurationSeconds(config?.durationSeconds ?? null);
+      } catch {
+        setLockedDurationSeconds(null);
+      }
+    };
+
+    loadDurationFromConfig();
+  }, [deeplinkDurationSeconds, draftId, draftMode]);
 
   React.useEffect(() => {
     if (serverNotSetupForUpload) {
@@ -189,6 +232,40 @@ export default function ShortsScreen() {
     (total, segment) => total + getEffectiveDuration(segment),
     0
   );
+  const totalUsedDurationSeconds =
+    totalRecordedDurationSeconds + activeRecordingDurationSeconds;
+  const isLockedDurationReached =
+    lockedDurationSeconds !== null &&
+    totalUsedDurationSeconds >= lockedDurationSeconds;
+  const shouldBlinkLockedDuration =
+    lockedDurationSeconds !== null &&
+    totalRecordedDurationSeconds >= lockedDurationSeconds &&
+    isRecording;
+  const shouldBlinkWarningIcon = isLockedDurationReached && isRecording;
+
+  React.useEffect(() => {
+    if (!shouldBlinkLockedDuration) {
+      setLockedDurationBlinkVisible(true);
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setLockedDurationBlinkVisible((prev) => !prev);
+    }, 500);
+    return () => clearInterval(timer);
+  }, [shouldBlinkLockedDuration]);
+
+  React.useEffect(() => {
+    if (!shouldBlinkWarningIcon) {
+      setWarningIconBlinkVisible(true);
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setWarningIconBlinkVisible((prev) => !prev);
+    }, 500);
+    return () => clearInterval(timer);
+  }, [shouldBlinkWarningIcon]);
 
   const handleRecordingStart = (
     mode: "tap" | "hold",
@@ -252,10 +329,22 @@ export default function ShortsScreen() {
 
   // Restore loaded duration when draft is loaded
   React.useEffect(() => {
+    if (lockedDurationSeconds !== null) {
+      if (maxDurationLimitSeconds !== lockedDurationSeconds) {
+        setMaxDurationLimitSeconds(lockedDurationSeconds);
+        updateDraftDuration(lockedDurationSeconds);
+      }
+      return;
+    }
     if (savedDurationLimitSeconds !== null && savedDurationLimitSeconds !== maxDurationLimitSeconds) {
       setMaxDurationLimitSeconds(savedDurationLimitSeconds);
     }
-  }, [savedDurationLimitSeconds, maxDurationLimitSeconds]);
+  }, [
+    lockedDurationSeconds,
+    savedDurationLimitSeconds,
+    maxDurationLimitSeconds,
+    updateDraftDuration,
+  ]);
 
   // Sync previousCameraFacing ref when cameraFacing changes
   React.useEffect(() => {
@@ -637,16 +726,36 @@ export default function ShortsScreen() {
                 <ThemedText style={styles.separatorText}>•</ThemedText>
               </>
             )}
-            <ThemedText style={styles.recordingTimeText}>
+            <ThemedText
+              style={[
+                styles.recordingTimeText,
+                isLockedDurationReached && styles.recordingTimeWarningText,
+                shouldBlinkLockedDuration &&
+                  !lockedDurationBlinkVisible &&
+                  styles.recordingTimeBlinkHidden,
+              ]}
+            >
               {(() => {
                 const totalSeconds = Math.round(
-                  totalRecordedDurationSeconds + activeRecordingDurationSeconds
+                  totalUsedDurationSeconds
                 );
                 const minutes = Math.floor(totalSeconds / 60);
                 const seconds = totalSeconds % 60;
                 return `${minutes}:${seconds.toString().padStart(2, "0")}`;
               })()}
             </ThemedText>
+            {isLockedDurationReached && (
+              <View
+                style={[
+                  styles.warningIconInline,
+                  shouldBlinkWarningIcon &&
+                    !warningIconBlinkVisible &&
+                    styles.warningIconBlinkHidden,
+                ]}
+              >
+                <MaterialIcons name="warning-amber" size={16} color="#ff4d4d" />
+              </View>
+            )}
           </View>
 
           <RecordButton
@@ -661,6 +770,7 @@ export default function ShortsScreen() {
             onButtonTouchStart={handleButtonTouchStart}
             onButtonTouchEnd={handleButtonTouchEnd}
             screenTouchActive={screenTouchActive}
+            allowRecordingPastTotalDuration={lockedDurationSeconds !== null}
           />
         </Animated.View>
       </GestureDetector>
@@ -668,10 +778,40 @@ export default function ShortsScreen() {
       {/* UI controls outside gesture handler to prevent touch event conflicts */}
       {!isRecording && (
         <View style={styles.timeSelectorContainer}>
-          <TimeSelectorButton
-            onTimeSelect={handleTimeSelect}
-            selectedTime={maxDurationLimitSeconds}
-          />
+          {lockedDurationSeconds !== null ? (
+            <View style={styles.lockedDurationContainer}>
+              <View
+                style={[
+                  styles.lockedDurationBadge,
+                  isLockedDurationReached && styles.lockedDurationBadgeWarning,
+                  shouldBlinkLockedDuration &&
+                    !lockedDurationBlinkVisible &&
+                    styles.lockedDurationBlinkHidden,
+                ]}
+              >
+                <ThemedText
+                  style={[
+                    styles.lockedDurationText,
+                    isLockedDurationReached && styles.lockedDurationTextWarning,
+                  ]}
+                >
+                  {lockedDurationSeconds >= 60
+                    ? `${Math.floor(lockedDurationSeconds / 60)}m${
+                        lockedDurationSeconds % 60
+                          ? ` ${lockedDurationSeconds % 60}s`
+                          : ""
+                      }`
+                    : `${lockedDurationSeconds}s`}
+                </ThemedText>
+              </View>
+
+            </View>
+          ) : (
+            <TimeSelectorButton
+              onTimeSelect={handleTimeSelect}
+              selectedTime={maxDurationLimitSeconds}
+            />
+          )}
         </View>
       )}
 
@@ -740,6 +880,46 @@ const styles = StyleSheet.create({
     right: 25,
     zIndex: 10,
   },
+  lockedDurationBadge: {
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    width: 56,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 8,
+  },
+  lockedDurationContainer: {
+    position: "relative",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  lockedDurationBadgeWarning: {
+    backgroundColor: "rgba(255, 0, 0, 0.25)",
+    borderWidth: 1,
+    borderColor: "#ff4d4d",
+  },
+  lockedDurationBlinkHidden: {
+    opacity: 0.35,
+  },
+  lockedDurationText: {
+    color: "#ffffff",
+    fontSize: 14,
+    fontWeight: "600",
+    fontFamily: "Roboto-Bold",
+    textAlign: "center",
+  },
+  lockedDurationTextWarning: {
+    color: "#ff4d4d",
+  },
+  warningIconInline: {
+    marginLeft: 8,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  warningIconBlinkHidden: {
+    opacity: 0.25,
+  },
   previewButton: {
     position: "absolute",
     bottom: 40,
@@ -788,6 +968,12 @@ const styles = StyleSheet.create({
     textShadowColor: "rgba(0, 0, 0, 0.7)",
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 2,
+  },
+  recordingTimeWarningText: {
+    color: "#ff4d4d",
+  },
+  recordingTimeBlinkHidden: {
+    opacity: 0.35,
   },
   videoLibraryButton: {
     position: "absolute",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,6 +20,13 @@ import { addDestination } from "@/utils/uploadDestinations";
 const isUUIDv4 = (uuid: string) =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(uuid);
 
+const parseDurationParam = (duration?: string | null): number | undefined => {
+  if (!duration) return undefined;
+  const parsed = Number.parseInt(duration, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+};
+
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const router = useRouter();
@@ -38,6 +45,7 @@ export default function RootLayout() {
       const server = search.get("server");
       const token = search.get("token");
       const name = search.get("name");
+      const duration = parseDurationParam(search.get("duration"));
 
       if (mode === "configure_destination" && server && token) {
         try {
@@ -58,13 +66,19 @@ export default function RootLayout() {
       const hasValidDraftId = draftId && isUUIDv4(draftId);
       if (hasValidDraftId && server && token) {
         try {
-          await storeUploadConfigForDraft(draftId, server, token);
+          await storeUploadConfigForDraft(draftId, server, token, duration);
         } catch (e) {
           console.warn("[Deeplink] Failed to store upload config:", e);
         }
         router.replace({
           pathname: "/(camera)/shorts",
-          params: { mode: "upload", draftId, server, token },
+          params: {
+            mode: "upload",
+            draftId,
+            server,
+            token,
+            ...(duration ? { duration: String(duration) } : {}),
+          },
         });
       } else {
         router.replace({
@@ -73,6 +87,7 @@ export default function RootLayout() {
             mode: "upload",
             ...(server && { server }),
             ...(token && { token }),
+            ...(duration ? { duration: String(duration) } : {}),
             serverNotSetupForUpload: "true",
           },
         });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -17,6 +17,13 @@ const isUUIDv4 = (uuid: string) => {
   return uuidv4Regex.test(uuid);
 };
 
+const parseDurationParam = (duration?: string | null): number | undefined => {
+  if (!duration) return undefined;
+  const parsed = Number.parseInt(duration, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+};
+
 export default function Index() {
   const params = useLocalSearchParams<{
     mode?: string;
@@ -24,12 +31,14 @@ export default function Index() {
     server?: string;
     token?: string;
     name?: string;
+    duration?: string;
     serverNotSetupForUpload?: string;
   }>();
   const router = useRouter();
   const [hasRedirected, setHasRedirected] = useState(false);
 
   const hasValidDraftId = params.draftId && isUUIDv4(params.draftId);
+  const parsedDuration = parseDurationParam(params.duration);
   const serverNotSetupForUpload =
     params.serverNotSetupForUpload === "true" ||
     (params.mode === "upload" &&
@@ -81,7 +90,8 @@ export default function Index() {
           await storeUploadConfigForDraft(
             params.draftId!,
             params.server,
-            params.token
+            params.token,
+            parsedDuration
           );
           console.log("✅ Stored upload config for draft", params.draftId);
         } catch (error) {
@@ -96,6 +106,7 @@ export default function Index() {
               draftId: params.draftId,
               server: params.server,
               token: params.token,
+              ...(parsedDuration ? { duration: String(parsedDuration) } : {}),
             },
           });
         }
@@ -108,6 +119,7 @@ export default function Index() {
     params.draftId,
     params.server,
     params.token,
+    parsedDuration,
     hasValidDraftId,
     router,
     hasRedirected,

--- a/app/merged-video.tsx
+++ b/app/merged-video.tsx
@@ -212,7 +212,7 @@ export default function MergedVideoScreen() {
   const isOverLockedDuration =
     lockedDurationSeconds !== null &&
     draftDurationSeconds !== null &&
-    draftDurationSeconds > lockedDurationSeconds;
+    draftDurationSeconds >= lockedDurationSeconds;
   const showDestinationPicker =
     !hasUploadConfig && destinations.length > 0 && draftId;
 

--- a/app/merged-video.tsx
+++ b/app/merged-video.tsx
@@ -42,6 +42,37 @@ export default function MergedVideoScreen() {
   const [destinations, setDestinations] = useState<UploadDestination[]>([]);
   const [selectedDestination, setSelectedDestination] =
     useState<UploadDestination | null>(null);
+  const [lockedDurationSeconds, setLockedDurationSeconds] = useState<number | null>(
+    null
+  );
+  const [draftDurationSeconds, setDraftDurationSeconds] = useState<number | null>(
+    null
+  );
+
+  const getEffectiveDuration = (segment: {
+    recordedDurationSeconds: number;
+    trimStartTimeMs?: number;
+    trimEndTimeMs?: number;
+  }): number => {
+    if (
+      segment.trimStartTimeMs !== undefined &&
+      segment.trimEndTimeMs !== undefined &&
+      segment.trimStartTimeMs >= 0 &&
+      segment.trimEndTimeMs > segment.trimStartTimeMs
+    ) {
+      return (segment.trimEndTimeMs - segment.trimStartTimeMs) / 1000;
+    }
+    return segment.recordedDurationSeconds;
+  };
+
+  const formatDurationLabel = (seconds: number): string => {
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return remainingSeconds > 0
+      ? `${minutes}m ${remainingSeconds}s`
+      : `${minutes}m`;
+  };
 
   const player = useVideoPlayer(videoUri, (player) => {
     player.loop = false;
@@ -90,6 +121,7 @@ export default function MergedVideoScreen() {
     const checkUploadConfig = async () => {
       const config = draftId ? await getUploadConfigForDraft(draftId) : null;
       setHasUploadConfig(!!config);
+      setLockedDurationSeconds(config?.durationSeconds ?? null);
 
       if (draftId) {
         try {
@@ -97,13 +129,22 @@ export default function MergedVideoScreen() {
                        await DraftStorage.getDraftById(draftId, "camera");
           if (draft) {
             setIsUploadModeDraft(draft.mode === "upload");
+            const total = draft.segments.reduce(
+              (acc, segment) => acc + getEffectiveDuration(segment),
+              0
+            );
+            setDraftDurationSeconds(total);
+          } else {
+            setDraftDurationSeconds(null);
           }
         } catch (error) {
           console.error("[MergedVideo] Failed to check draft mode:", error);
           setIsUploadModeDraft(false);
+          setDraftDurationSeconds(null);
         }
       } else {
         setIsUploadModeDraft(false);
+        setDraftDurationSeconds(null);
       }
     };
     checkUploadConfig();
@@ -168,6 +209,10 @@ export default function MergedVideoScreen() {
 
   const canUploadWithDestination =
     draftId && (hasUploadConfig || selectedDestination);
+  const isOverLockedDuration =
+    lockedDurationSeconds !== null &&
+    draftDurationSeconds !== null &&
+    draftDurationSeconds > lockedDurationSeconds;
   const showDestinationPicker =
     !hasUploadConfig && destinations.length > 0 && draftId;
 
@@ -180,6 +225,10 @@ export default function MergedVideoScreen() {
         "This recording has no draft. Save as draft first.",
         [{ text: "OK" }]
       );
+      return;
+    }
+
+    if (isOverLockedDuration) {
       return;
     }
 
@@ -418,17 +467,30 @@ export default function MergedVideoScreen() {
           </View>
         )}
 
+        {isOverLockedDuration && (
+          <View style={styles.durationWarningSection}>
+            <MaterialIcons name="warning-amber" size={18} color="#ff4d4d" />
+            <ThemedText style={styles.durationWarningText}>
+              {`This video is ${formatDurationLabel(
+                Math.round(draftDurationSeconds ?? 0)
+              )}. It must be under ${formatDurationLabel(
+                lockedDurationSeconds ?? 0
+              )} to upload.`}
+            </ThemedText>
+          </View>
+        )}
+
         {/* Action Buttons */}
         <View style={styles.actionButtons}>
           <TouchableOpacity
             style={[
               styles.uploadButton,
-              (!canUploadWithDestination || isUploading) &&
+              (!canUploadWithDestination || isUploading || isOverLockedDuration) &&
                 styles.uploadButtonDisabled,
             ]}
             onPress={handleUpload}
             activeOpacity={0.8}
-            disabled={!canUploadWithDestination || isUploading}
+            disabled={!canUploadWithDestination || isUploading || isOverLockedDuration}
           >
             {isUploading ? (
               <ActivityIndicator size="small" color="#ffffff" />
@@ -670,6 +732,19 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#999",
     textAlign: "center",
+  },
+  durationWarningSection: {
+    paddingHorizontal: 16,
+    marginBottom: 12,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+  },
+  durationWarningText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
+    color: "#ff4d4d",
   },
   separator: {
     flexDirection: "row",

--- a/components/RecordButton.tsx
+++ b/components/RecordButton.tsx
@@ -129,7 +129,8 @@ export default function RecordButton({
     const sessionMaxDuration = shouldEnforceTotalLimit
       ? Math.min(maxDuration, remainingTime)
       : maxDuration;
-    onRecordingStart?.(mode, remainingTime);
+    const clampedRemainingTime = Math.max(0, remainingTime);
+    onRecordingStart?.(mode, clampedRemainingTime);
     progressIntervalRef.current = setInterval(() => {
       const currentRecordingDuration =
         (Date.now() - recordingStartTimeRef.current) / 1000;

--- a/components/RecordButton.tsx
+++ b/components/RecordButton.tsx
@@ -24,6 +24,7 @@ interface RecordButtonProps {
   onButtonTouchStart?: () => void;
   onButtonTouchEnd?: () => void;
   screenTouchActive?: boolean;
+  allowRecordingPastTotalDuration?: boolean;
 }
 
 export default function RecordButton({
@@ -40,6 +41,7 @@ export default function RecordButton({
   onButtonTouchStart,
   onButtonTouchEnd,
   screenTouchActive = false,
+  allowRecordingPastTotalDuration = false,
 }: RecordButtonProps) {
   const [isRecording, setIsRecording] = React.useState(false);
   const [recordingMode, setRecordingMode] = React.useState<
@@ -69,6 +71,7 @@ export default function RecordButton({
   const progressIntervalRef = React.useRef<ReturnType<
     typeof setInterval
   > | null>(null);
+  const enforceTotalLimitForSessionRef = React.useRef<boolean>(true);
 
   const remainingTime = totalDuration - usedDuration;
 
@@ -106,7 +109,14 @@ export default function RecordButton({
   }, [screenTouchActive, buttonInitiatedRecording, isRecording, recordingMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const startRecording = (mode: "tap" | "hold") => {
-    if (!cameraRef.current || isRecording || remainingTime <= 0) return;
+    const canStartWhenAtLimit = allowRecordingPastTotalDuration;
+    if (
+      !cameraRef.current ||
+      isRecording ||
+      (remainingTime <= 0 && !canStartWhenAtLimit)
+    ) {
+      return;
+    }
 
     setIsRecording(true);
     setRecordingMode(mode);
@@ -114,7 +124,11 @@ export default function RecordButton({
     manuallyStoppedRef.current = false;
     recordingStartTimeRef.current = Date.now();
 
-    const sessionMaxDuration = Math.min(maxDuration, remainingTime);
+    const shouldEnforceTotalLimit = remainingTime > 0;
+    enforceTotalLimitForSessionRef.current = shouldEnforceTotalLimit;
+    const sessionMaxDuration = shouldEnforceTotalLimit
+      ? Math.min(maxDuration, remainingTime)
+      : maxDuration;
     onRecordingStart?.(mode, remainingTime);
     progressIntervalRef.current = setInterval(() => {
       const currentRecordingDuration =
@@ -126,7 +140,7 @@ export default function RecordButton({
         Math.max(0, newRemainingTime)
       );
 
-      if (newRemainingTime <= 0) {
+      if (enforceTotalLimitForSessionRef.current && newRemainingTime <= 0) {
         stopRecording();
         if (mode === "hold") {
           stopHoldVisualFeedback();

--- a/components/RecordButton.tsx
+++ b/components/RecordButton.tsx
@@ -124,7 +124,7 @@ export default function RecordButton({
     manuallyStoppedRef.current = false;
     recordingStartTimeRef.current = Date.now();
 
-    const shouldEnforceTotalLimit = remainingTime > 0;
+    const shouldEnforceTotalLimit = !allowRecordingPastTotalDuration && remainingTime > 0;
     enforceTotalLimitForSessionRef.current = shouldEnforceTotalLimit;
     const sessionMaxDuration = shouldEnforceTotalLimit
       ? Math.min(maxDuration, remainingTime)

--- a/utils/uploadConfig.ts
+++ b/utils/uploadConfig.ts
@@ -5,6 +5,17 @@ const UPLOAD_CONFIG_PREFIX = "upload_config_";
 export interface UploadConfig {
   server: string;
   token: string;
+  durationSeconds?: number;
+}
+
+function parseDurationSeconds(duration?: string | number | null): number | undefined {
+  if (duration == null) return undefined;
+  const parsed =
+    typeof duration === "number"
+      ? duration
+      : Number.parseInt(String(duration), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
 }
 
 /**
@@ -15,13 +26,19 @@ export interface UploadConfig {
 export async function storeUploadConfigForDraft(
   draftId: string,
   server: string,
-  token: string
+  token: string,
+  durationSeconds?: number
 ): Promise<void> {
   try {
     const key = UPLOAD_CONFIG_PREFIX + draftId;
+    const safeDuration = parseDurationSeconds(durationSeconds);
     await AsyncStorage.setItem(
       key,
-      JSON.stringify({ server, token })
+      JSON.stringify({
+        server,
+        token,
+        ...(safeDuration ? { durationSeconds: safeDuration } : {}),
+      })
     );
     console.log("[UploadConfig] Stored config for draft:", draftId);
   } catch (error) {
@@ -41,9 +58,17 @@ export async function getUploadConfigForDraft(
     const key = UPLOAD_CONFIG_PREFIX + draftId;
     const raw = await AsyncStorage.getItem(key);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as { server?: string; token?: string };
+    const parsed = JSON.parse(raw) as {
+      server?: string;
+      token?: string;
+      durationSeconds?: number | string;
+    };
     if (parsed?.server && parsed?.token) {
-      return { server: parsed.server, token: parsed.token };
+      return {
+        server: parsed.server,
+        token: parsed.token,
+        durationSeconds: parseDurationSeconds(parsed.durationSeconds),
+      };
     }
     return null;
   } catch (error) {
@@ -67,9 +92,17 @@ export async function getUploadConfigsForDraftIds(
       const [, value] = pairs[i];
       if (value) {
         try {
-          const parsed = JSON.parse(value) as { server?: string; token?: string };
+          const parsed = JSON.parse(value) as {
+            server?: string;
+            token?: string;
+            durationSeconds?: number | string;
+          };
           if (parsed?.server && parsed?.token) {
-            map.set(draftIds[i], { server: parsed.server, token: parsed.token });
+            map.set(draftIds[i], {
+              server: parsed.server,
+              token: parsed.token,
+              durationSeconds: parseDurationSeconds(parsed.durationSeconds),
+            });
           }
         } catch {
           // skip invalid entry


### PR DESCRIPTION

### Summary
This PR improves deeplink-duration handling across recording and upload flows.

It introduces clearer warning behavior when users hit/exceed a locked duration, ensures uploads are blocked via disabled state (with inline explanation), and fixes a trim-sync bug where Shorts screen could still show stale over-limit warnings after trimming below the limit.

### Demo
https://youtube.com/shorts/zvwQoqCpy_M


### What changed
#### 1) Recording behavior in Shorts (`app/(camera)/shorts.tsx`, `components/RecordButton.tsx`)
- Allowed recording to continue in deeplink-locked mode after total duration is reached (while preserving stop behavior at threshold crossing for each segment).
- Added warning visuals when limit is reached/exceeded:
  - timer text turns red,
  - warning icon shown next to timer,
  - icon blinks only while actively recording and stays steady after recording stops.

#### 2) Upload gating in merged screen (`app/merged-video.tsx`)
- Added trim-aware effective duration checks against locked deeplink duration.
- Replaced blocking alert popup with an inline warning message.
- Disabled **Upload to Cloud** button when over locked duration.
- Kept upload guard in handler as safety fallback.

#### 3) Trim-sync bug fix in Shorts (`app/(camera)/shorts.tsx`)
- Fixed draft reload on focus to fetch draft by active mode (`camera`/`upload`) with fallback to the other mode.
- This ensures trimmed segment durations are refreshed correctly after returning from trim/reorder screens.
- Result: if trimming reduces total below lock, red warning state clears and timer returns to normal.

### Files changed
- `components/RecordButton.tsx`
- `app/(camera)/shorts.tsx`
- `app/merged-video.tsx`


## How to test
1. Open app via deeplink/QR with a locked duration.
2. Record until reaching/exceeding limit.
   - Verify timer turns red and warning icon appears.
   - While recording over limit, warning icon blinks.
   - Stop recording: icon remains visible but stops blinking.
3. Go to reorder/trim, trim enough to get below limit.
4. Return to Shorts.
   - Verify timer/warning state resets to normal.
5. Go to merged/upload screen.
   - If over limit: inline warning is shown and Upload button is disabled.
   - If trimmed below limit: warning disappears and Upload button is enabled (assuming destination/config is valid).

## Notes
- Duration calculations are trim-aware (`trimStartTimeMs`/`trimEndTimeMs`).
- Type-check was run during development (`npx tsc --noEmit`).