### PR TITLE
feat: stop background audio during recording, resume after

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ android/build/
 android/.gradle/
 modules/video-concat/android/build/
 modules/video-concat/android/.gradle/
+modules/audio-focus/android/build/
+modules/audio-focus/android/.gradle/
 *.apk
 *.aab
 local.properties

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>

--- a/app.json
+++ b/app.json
@@ -63,7 +63,8 @@
         }
       ],
       "expo-video",
-      "expo-web-browser"
+      "expo-web-browser",
+      "expo-audio"
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -14,6 +14,7 @@ import UndoSegmentButton from "@/components/UndoSegmentButton";
 import * as ImagePicker from "expo-image-picker";
 import * as VideoThumbnails from "expo-video-thumbnails";
 import { useDraftManager } from "@/hooks/useDraftManager";
+import { useAudioSession } from "@/hooks/useAudioSession";
 import { useVideoStabilization } from "@/hooks/useVideoStabilization";
 import { useCameraFacing } from "@/hooks/useCameraFacing";
 import {
@@ -190,7 +191,9 @@ export default function ShortsScreen() {
     0
   );
 
-  const handleRecordingStart = (
+  const { activateRecordingSession, deactivateRecordingSession } = useAudioSession();
+
+  const handleRecordingStart = async (
     mode: "tap" | "hold",
     remainingTime: number
   ) => {
@@ -201,6 +204,7 @@ export default function ShortsScreen() {
     // Only set isHoldRecording for hold mode
     isHoldRecording.value = mode === "hold";
     recordingModeShared.value = mode;
+    await activateRecordingSession();
   };
 
   const handleRecordingProgress = (
@@ -217,6 +221,9 @@ export default function ShortsScreen() {
   ) => {
     setActiveRecordingDurationSeconds(0);
     setIsRecording(false);
+
+    // Release microphone and let background apps resume audio.
+    deactivateRecordingSession();
 
     // Reset shared values and screen touch state
     isHoldRecording.value = false;
@@ -283,7 +290,14 @@ export default function ShortsScreen() {
         setCameraKey(prev => prev + 1);
         needsCameraRemountRef.current = false;
       }
-      
+
+      // Claim audio focus as soon as the camera screen mounts.
+      // On Android this calls AudioManager.requestAudioFocus(AUDIOFOCUS_GAIN)
+      // which stops Spotify / podcasts / etc. BEFORE the user taps Record.
+      // This avoids a race condition where recordAsync() would start before
+      // the async setIsAudioActiveAsync(true) had completed.
+      // activateRecordingSession();
+
       const reloadDraft = async () => {
         const draftToReload = draftId || currentDraftId;
         if (draftToReload) {
@@ -309,7 +323,13 @@ export default function ShortsScreen() {
         }
       };
       reloadDraft();
-    }, [draftId, currentDraftId, setRecordingSegments, maxDurationLimitSeconds])
+
+      // Ensure clean audio state when the user leaves the camera screen
+      // (e.g. navigated away mid-session or app backgrounded during recording).
+      return () => {
+        deactivateRecordingSession();
+      };
+    }, [draftId, currentDraftId, setRecordingSegments, maxDurationLimitSeconds, deactivateRecordingSession])
   );
 
   const handleTimeSelect = (newDurationLimitSeconds: number) => {

--- a/hooks/useAudioSession.ts
+++ b/hooks/useAudioSession.ts
@@ -1,0 +1,97 @@
+import { useCallback } from "react";
+import { Platform } from "react-native";
+import { setAudioModeAsync } from "expo-audio";
+import { requestAudioFocus, abandonAudioFocus } from "@/modules/audio-focus/src/AudioFocusModule";
+
+/**
+ * Manages the iOS/Android audio session for video recording.
+ *
+ * ─── ANDROID ──────────────────────────────────────────────────────────────
+ *
+ * Uses the local `audio-focus` native module which calls
+ * AudioManager.requestAudioFocus(AUDIOFOCUS_GAIN) directly.
+ * This is the OS-level signal that causes Spotify / YouTube Music / podcasts
+ * to pause immediately.
+ *
+ * Why not expo-audio's setIsAudioActiveAsync?
+ * → It is a NO-OP on Android (only sets an internal flag, never calls
+ *   requestAudioFocus). Confirmed from AudioModule.kt lines 183-195.
+ *
+ * ─── iOS ───────────────────────────────────────────────────────────────────
+ *
+ * setAudioModeAsync configures the AVAudioSession category (doNotMix + mic).
+ * The native AudioFocusModule then calls:
+ *   requestAudioFocus  → AVAudioSession.setActive(true)          (stops Spotify)
+ *   abandonAudioFocus  → AVAudioSession.setActive(false,          (resumes Spotify)
+ *                          options: .notifyOthersOnDeactivation)
+ *
+ * Without .notifyOthersOnDeactivation, iOS does NOT signal other apps to resume.
+ *
+ * ─── expo-audio BUG (still in v1.0.13) ────────────────────────────────────
+ *
+ * https://github.com/expo/expo/issues/34025
+ * Passing both `interruptionMode` (iOS) and `interruptionModeAndroid` in the
+ * same setAudioModeAsync call crashes Android. We spread only the
+ * platform-relevant interruption key using Platform.OS.
+ */
+export function useAudioSession() {
+  /**
+   * Claim audio focus so background apps stop playing.
+   *
+   * Android: calls AudioManager.requestAudioFocus(AUDIOFOCUS_GAIN) directly.
+   * iOS:     configures AVAudioSession with DoNotMix and enables the mic.
+   */
+  const activateRecordingSession = useCallback(async () => {
+    try {
+      // Configure the audio mode first (sets AVAudioSession category on iOS,
+      // sets interruptionMode on Android) before claiming focus.
+      await setAudioModeAsync({
+        allowsRecording: true,
+        playsInSilentMode: true,
+        ...(Platform.OS === "ios"
+          ? { interruptionMode: "doNotMix" }
+          : { interruptionModeAndroid: "doNotMix" }),
+        shouldPlayInBackground: false,
+      });
+
+      // Claim audio focus on both platforms:
+      // Android → AudioManager.requestAudioFocus(AUDIOFOCUS_GAIN_TRANSIENT)
+      // iOS     → AVAudioSession.setActive(true)
+      // Both signals cause Spotify/podcasts to pause.
+      await requestAudioFocus();
+
+      console.log("[AudioSession] Recording session activated — background audio stopped.");
+    } catch (error) {
+      console.warn("[AudioSession] Failed to activate recording session:", error);
+    }
+  }, []);
+
+  /**
+   * Release audio focus after recording ends or on screen unmount.
+   * Allows background apps to resume their playback.
+   */
+  const deactivateRecordingSession = useCallback(async () => {
+    try {
+      // Release focus on both platforms:
+      // Android → AudioManager.abandonAudioFocus()
+      // iOS     → AVAudioSession.setActive(false, options: .notifyOthersOnDeactivation)
+      // The notifyOthersOnDeactivation flag is what tells Spotify/podcasts to resume.
+      await abandonAudioFocus();
+
+      await setAudioModeAsync({
+        allowsRecording: false,
+        playsInSilentMode: false,
+        ...(Platform.OS === "ios"
+          ? { interruptionMode: "mixWithOthers" }
+          : { interruptionModeAndroid: "duckOthers" }),
+        shouldPlayInBackground: false,
+      });
+
+      console.log("[AudioSession] Recording session deactivated — background audio restored.");
+    } catch (error) {
+      console.warn("[AudioSession] Failed to deactivate recording session:", error);
+    }
+  }, []);
+
+  return { activateRecordingSession, deactivateRecordingSession };
+}

--- a/modules/audio-focus/android/build.gradle
+++ b/modules/audio-focus/android/build.gradle
@@ -1,0 +1,39 @@
+apply plugin: 'com.android.library'
+
+group = 'expo.modules.audiofocus'
+version = '1.0.0'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+
+def useManagedAndroidSdkVersions = false
+if (useManagedAndroidSdkVersions) {
+  useDefaultAndroidSdkVersions()
+} else {
+  buildscript {
+    ext.safeExtGet = { prop, fallback ->
+      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+  }
+  project.android {
+    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    defaultConfig {
+      minSdkVersion safeExtGet("minSdkVersion", 21)
+      targetSdkVersion safeExtGet("targetSdkVersion", 34)
+    }
+  }
+}
+
+android {
+  namespace "expo.modules.audiofocus"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/modules/audio-focus/android/src/main/AndroidManifest.xml
+++ b/modules/audio-focus/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/audio-focus/android/src/main/java/expo/modules/audiofocus/AudioFocusModule.kt
+++ b/modules/audio-focus/android/src/main/java/expo/modules/audiofocus/AudioFocusModule.kt
@@ -1,0 +1,54 @@
+package expo.modules.audiofocus
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class AudioFocusModule : Module() {
+  private var focusRequest: AudioFocusRequest? = null
+
+  private val audioManager: AudioManager
+    get() = appContext.reactContext!!.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+  override fun definition() = ModuleDefinition {
+    Name("AudioFocus")
+
+    AsyncFunction("requestAudioFocus") {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val attrs = AudioAttributes.Builder()
+          .setUsage(AudioAttributes.USAGE_MEDIA)
+          .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+          .build()
+
+        val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+          .setAudioAttributes(attrs)
+          .setAcceptsDelayedFocusGain(false)
+          .build()
+
+        focusRequest = request
+        audioManager.requestAudioFocus(request)
+      } else {
+        @Suppress("DEPRECATION")
+        audioManager.requestAudioFocus(
+          null,
+          AudioManager.STREAM_MUSIC,
+          AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
+        )
+      }
+    }
+
+    AsyncFunction("abandonAudioFocus") {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        focusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+        focusRequest = null
+      } else {
+        @Suppress("DEPRECATION")
+        audioManager.abandonAudioFocus(null)
+      }
+    }
+  }
+}

--- a/modules/audio-focus/expo-module.config.json
+++ b/modules/audio-focus/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["AudioFocusModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.audiofocus.AudioFocusModule"]
+  }
+}

--- a/modules/audio-focus/index.ts
+++ b/modules/audio-focus/index.ts
@@ -1,0 +1,1 @@
+export { requestAudioFocus, abandonAudioFocus } from "./src/AudioFocusModule";

--- a/modules/audio-focus/ios/AudioFocus.podspec
+++ b/modules/audio-focus/ios/AudioFocus.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name           = 'AudioFocus'
+  s.version        = '1.0.0'
+  s.summary        = 'Direct Android AudioManager audio focus requests'
+  s.description    = 'Local Expo module to request/abandon Android audio focus so background apps pause during camera recording.'
+  s.author         = ''
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/audio-focus/ios/AudioFocusModule.swift
+++ b/modules/audio-focus/ios/AudioFocusModule.swift
@@ -1,0 +1,25 @@
+import ExpoModulesCore
+import AVFoundation
+
+public class AudioFocusModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("AudioFocus")
+
+    // Activate the AVAudioSession so other apps (Spotify, podcasts) are interrupted.
+    // setAudioModeAsync has already set the category/options via expo-audio;
+    // we just flip the session active here.
+    AsyncFunction("requestAudioFocus") {
+      try AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    // Deactivate with .notifyOthersOnDeactivation — the iOS equivalent of
+    // abandonAudioFocus on Android. This is the signal that tells Spotify /
+    // podcasts / music apps that they can resume playback.
+    AsyncFunction("abandonAudioFocus") {
+      try AVAudioSession.sharedInstance().setActive(
+        false,
+        options: .notifyOthersOnDeactivation
+      )
+    }
+  }
+}

--- a/modules/audio-focus/src/AudioFocusModule.ts
+++ b/modules/audio-focus/src/AudioFocusModule.ts
@@ -1,0 +1,20 @@
+import { requireNativeModule } from "expo";
+
+const AudioFocusModule = requireNativeModule("AudioFocus");
+
+/**
+ * Requests Android audio focus with AUDIOFOCUS_GAIN.
+ * This causes other apps (Spotify, podcasts, YouTube Music) to pause.
+ * No-op on iOS (handled by expo-audio's setAudioModeAsync).
+ */
+export async function requestAudioFocus(): Promise<void> {
+  return AudioFocusModule.requestAudioFocus();
+}
+
+/**
+ * Abandons Android audio focus so other apps can resume.
+ * No-op on iOS.
+ */
+export async function abandonAudioFocus(): Promise<void> {
+  return AudioFocusModule.abandonAudioFocus();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
         "expo": "~53.0.23",
+        "expo-audio": "~0.4.9",
         "expo-blur": "~14.1.5",
         "expo-camera": "~16.1.11",
         "expo-constants": "~17.1.6",
@@ -6175,6 +6176,17 @@
         "@expo/image-utils": "^0.7.6",
         "expo-constants": "~17.1.7"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-audio": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-0.4.9.tgz",
+      "integrity": "sha512-J4mMYEt2mqRqqwmSsXFylMGlrNWa+MbCzGl1IZBs+smvPAMJ3Ni8fNplzCQ0I9RnRzygKhRwJNpnAVL+n4MuyA==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.23",
+    "expo-audio": "~0.4.9",
     "expo-blur": "~14.1.5",
     "expo-camera": "~16.1.11",
     "expo-constants": "~17.1.6",


### PR DESCRIPTION
### Description

Pulse now will handle the background app playing while recording the audio. 
Added a local native Expo module (audio-focus) that directly controls the OS-level audio focus on both Android and iOS. A `useAudioSession` hook integrates it into the recording flow.

---
### Demo
[LINK](https://youtube.com/shorts/C4UhYqzByzg)

---

### How it works

**Android**
- `requestAudioFocus` → `AudioManager.requestAudioFocus(AUDIOFOCUS_GAIN_TRANSIENT)` — OS signal that causes Spotify/podcasts to pause
- `abandonAudioFocus` → `AudioManager.abandonAudioFocus()` — tells Spotify/podcasts they can resume

`AUDIOFOCUS_GAIN_TRANSIENT` (not `AUDIOFOCUS_GAIN`) is intentional — transient means Spotify receives `AUDIOFOCUS_LOSS_TRANSIENT` and automatically resumes when we're done.

> **Why not `expo-audio`'s `setIsAudioActiveAsync`?**
> It is a complete no-op on Android — it only sets an internal flag and never calls `requestAudioFocus`. Confirmed in `AudioModule.kt` lines 183–195.

**iOS**
- `requestAudioFocus` → `AVAudioSession.setActive(true)` — activates session, interrupting other apps
- `abandonAudioFocus` → `AVAudioSession.setActive(false, options: .notifyOthersOnDeactivation)` — the `.notifyOthersOnDeactivation` flag is the iOS signal that tells Spotify/Apple Music to resume. Without this flag, they stay paused indefinitely.

`setAudioModeAsync` (expo-audio) configures the AVAudioSession category (`playAndRecord`, `doNotMix`) on both platforms before focus is claimed.

---

### Files changed

| File | Change |
|---|---|
| audio-focus | New local native Expo module (Kotlin + Swift) |
| useAudioSession.ts | New hook — `activateRecordingSession` / `deactivateRecordingSession` |
| shorts.tsx | Calls activate on record tap, deactivate on stop and screen unmount |
| AndroidManifest.xml | Adds `MODIFY_AUDIO_SETTINGS` permission |
| .gitignore | Excludes `audio-focus` Android build output |

---

### Bug fixed during implementation

**[expo/expo#34025](https://github.com/expo/expo/issues/34025)** — passing both `interruptionMode` (iOS) and `interruptionModeAndroid` in the same `setAudioModeAsync` call crashes on Android with a Kotlin enum cast error. Fixed by spreading only the platform-relevant key via `Platform.OS`.

---

### Testing

1. Start playing music in Spotify
2. Open the camera screen → music pauses immediately
3. Record a clip → silence throughout
4. Stop recording → Spotify resumes automatically ✅

NOTE: Tested in Android. **This need to be tested in iOS.**